### PR TITLE
Output stream is now initialised before processing records; Version code added to header;

### DIFF
--- a/ContinuumHash/HashNetPlugin.cs
+++ b/ContinuumHash/HashNetPlugin.cs
@@ -99,6 +99,8 @@ namespace ContinuumHash
         {
             _recordInfoIn = recordInfo;
 
+            prepRecordInfoOut(); // This allows zero record run to succeed and fixes problem with downstream tool complaining about a stream not being initialized.
+
             return true;
         }
 
@@ -124,12 +126,7 @@ namespace ContinuumHash
 
         public bool II_PushRecord(RecordData recordDataIn)
         {
-            if (_recordInfoOut == null)
-            {
-                // Prep the output once
-                populateRecordInfoOut();
-                _outputHelper.Init(_recordInfoOut, "Output", null, _xmlProperties);
-            }
+            prepRecordInfoOut();
 
             string secret = getFieldBaseStringData(_secretField, recordDataIn);
             string message = getFieldBaseStringData(_messageField, recordDataIn);
@@ -281,6 +278,16 @@ namespace ContinuumHash
                 {
                     fbOut.SetFromString(recordOut, fbData);
                 }
+            }
+        }
+
+        private void prepRecordInfoOut()
+        {
+            if (_recordInfoOut == null)
+            {
+                // Prep the output once
+                populateRecordInfoOut();
+                _outputHelper.Init(_recordInfoOut, "Output", null, _xmlProperties);
             }
         }
 

--- a/ContinuumHash/HashUserControl.Designer.cs
+++ b/ContinuumHash/HashUserControl.Designer.cs
@@ -40,8 +40,9 @@
             this.comboBoxAlgo = new System.Windows.Forms.ComboBox();
             this.labelHashAlgo = new System.Windows.Forms.Label();
             this.panel5 = new System.Windows.Forms.Panel();
-            this.labelHashOutputField = new System.Windows.Forms.Label();
             this.textBoxOutputField = new System.Windows.Forms.TextBox();
+            this.labelHashOutputField = new System.Windows.Forms.Label();
+            this.labelVersion = new System.Windows.Forms.Label();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panel3.SuspendLayout();
@@ -51,6 +52,7 @@
             // 
             // panel1
             // 
+            this.panel1.Controls.Add(this.labelVersion);
             this.panel1.Controls.Add(this.labelHashHeader);
             this.panel1.Location = new System.Drawing.Point(0, 0);
             this.panel1.Name = "panel1";
@@ -154,6 +156,13 @@
             this.panel5.Size = new System.Drawing.Size(300, 50);
             this.panel5.TabIndex = 4;
             // 
+            // textBoxOutputField
+            // 
+            this.textBoxOutputField.Location = new System.Drawing.Point(105, 15);
+            this.textBoxOutputField.Name = "textBoxOutputField";
+            this.textBoxOutputField.Size = new System.Drawing.Size(180, 20);
+            this.textBoxOutputField.TabIndex = 2;
+            // 
             // labelHashOutputField
             // 
             this.labelHashOutputField.AutoSize = true;
@@ -163,12 +172,15 @@
             this.labelHashOutputField.TabIndex = 1;
             this.labelHashOutputField.Text = "Output Field:";
             // 
-            // textBoxOutputField
+            // labelVersion
             // 
-            this.textBoxOutputField.Location = new System.Drawing.Point(105, 15);
-            this.textBoxOutputField.Name = "textBoxOutputField";
-            this.textBoxOutputField.Size = new System.Drawing.Size(180, 20);
-            this.textBoxOutputField.TabIndex = 2;
+            this.labelVersion.AutoSize = true;
+            this.labelVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelVersion.Location = new System.Drawing.Point(67, 22);
+            this.labelVersion.Name = "labelVersion";
+            this.labelVersion.Size = new System.Drawing.Size(46, 13);
+            this.labelVersion.TabIndex = 1;
+            this.labelVersion.Text = "(v 1.0.1)";
             // 
             // HashUserControl
             // 
@@ -211,5 +223,6 @@
         private System.Windows.Forms.Panel panel5;
         private System.Windows.Forms.Label labelHashOutputField;
         private System.Windows.Forms.TextBox textBoxOutputField;
+        private System.Windows.Forms.Label labelVersion;
     }
 }


### PR DESCRIPTION
BRANCH: 2017-10-18_LT3_FixTargetStreamNotInitialized_VersionControl

CHANGED: ContinuumHash/HashNetPlugin.cs
 - prepRecordInfoOut() added to initialise out record header.
 - II_Init() now calls prepRecordInfoOut() .
 - II_PushRecordsInfoOut() now calls prepRecordInfoOut() as insurance.

CHANGED: ContinuumHash/HashUserControl.Designer.cs
 - Version label added.